### PR TITLE
scripts: add help scripts to generate pre-defined kconfigs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ The base-defconfig is intended to provide basic support for all platforms curren
 
 sof-defconfig lists all the options for SOF.
 sst-defconfig lists all the options for the SST driver.
-hdaudio-defconfig lists all the options for HDaudio codec support
+hdaudio-defconfig lists all the options for HDaudio codec support.
+sof-mach-driver-defconfig lists all the optiosn for SOF enabled machine driver support.
+soundwire-defconfig lists all the options for SoundWire support.
 
 Those fragments are supposed to be applied on top of a default kernel
 configuration.
@@ -21,12 +23,30 @@ cd <your kernel>
 make defconfig
 ````
 
-Then select one of the three options
-
+The following options are some example how to use defconfigs:
+- HDA
 ````bash
 scripts/kconfig/merge_config.sh .config <PATH>/kconfig/base-defconfig <PATH>/kconfig/hdaudio-codecs-defconfig
+````
+- SST
+````bash
 scripts/kconfig/merge_config.sh .config <PATH>/kconfig/base-defconfig <PATH>/kconfig/sst-defconfig <PATH>/kconfig/hdaudio-codecs-defconfig
-scripts/kconfig/merge_config.sh .config <PATH>/kconfig/base-defconfig <PATH>/kconfig/sof-defconfig <PATH>/kconfig/sof-mach-driver-defconfig <PATH>/kconfig/hdaudio-codecs-defconfig
+````
+- SOF-NOCODEC: SOF in nocodec debug mode
+````bash
+scripts/kconfig/merge_config.sh .config <PATH>/kconfig/base-defconfig <PATH>/kconfig/sof-defconfig <PATH>/kconfig/nocodec-defconfig
+````
+- SOF-DEFAULT: SOF support with I2S, HDA and SDW support with machine drivers
+````bash
+scripts/kconfig/merge_config.sh .config <PATH>/kconfig/base-defconfig <PATH>/kconfig/sof-defconfig <PATH>/kconfig/sof-mach-driver-defconfig <PATH>/kconfig/hdaudio-codecs-defconfig <PATH>/kconfig/soundwire-defconfig
+````
+
+Or you can generate above pre-defined kconfig with scripts:
+````bash
+<PATH>/kconfig/kconfig-hda.sh
+<PATH>/kconfig/kconfig-sst.sh
+<PATH>/kconfig/kconfig-sof-nocodec.sh
+<PATH>/kconfig/kconfig-sof-default.sh
 ````
 
 then build as usual
@@ -40,7 +60,7 @@ Additional fragments:
 - compile-test-defconfig: turn on compilation checks
 - debug-defconfig: turn on debug hooks
 - edison-defconfig: configuration for Edison provided by Andy Shevchenko
-- igb-tsn-defconfig: configuration for I210/I211 
+- igb-tsn-defconfig: configuration for I210/I211
 - memory-debug-defconfig: KASAN and friends debug
 - nocodec-defconfig: interface-level tests for SSP/DMIC
 - nopm-defconfig: turn off PM completely

--- a/kconfig-hda.sh
+++ b/kconfig-hda.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
+echo $KCONFIG_DIR
+make defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig

--- a/kconfig-sof-default.sh
+++ b/kconfig-sof-default.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
+echo $KCONFIG_DIR
+make defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sof-defconfig $KCONFIG_DIR/sof-mach-driver-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig $KCONFIG_DIR/soundwire-defconfig

--- a/kconfig-sof-nocodec.sh
+++ b/kconfig-sof-nocodec.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
+echo $KCONFIG_DIR
+make defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sof-defconfig $KCONFIG_DIR/nocodec-defconfig

--- a/kconfig-sst.sh
+++ b/kconfig-sst.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
+echo $KCONFIG_DIR
+make defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sst-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig


### PR DESCRIPTION
Add scritps for hda, sst, sof-nocodec and sof-default kconfig.
Also update the README

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>