### PR TITLE
scripts: add attached options for kconfig

### DIFF
--- a/kconfig-hda.sh
+++ b/kconfig-hda.sh
@@ -2,4 +2,4 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 make defconfig
-scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig $@

--- a/kconfig-sof-default.sh
+++ b/kconfig-sof-default.sh
@@ -2,4 +2,4 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 make defconfig
-scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sof-defconfig $KCONFIG_DIR/sof-mach-driver-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig $KCONFIG_DIR/soundwire-defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sof-defconfig $KCONFIG_DIR/sof-mach-driver-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig $KCONFIG_DIR/soundwire-defconfig $@

--- a/kconfig-sof-nocodec.sh
+++ b/kconfig-sof-nocodec.sh
@@ -2,4 +2,4 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 make defconfig
-scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sof-defconfig $KCONFIG_DIR/nocodec-defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sof-defconfig $KCONFIG_DIR/nocodec-defconfig $@

--- a/kconfig-sst.sh
+++ b/kconfig-sst.sh
@@ -2,4 +2,4 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 make defconfig
-scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sst-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig
+scripts/kconfig/merge_config.sh .config $KCONFIG_DIR/base-defconfig $KCONFIG_DIR/sst-defconfig $KCONFIG_DIR/hdaudio-codecs-defconfig $@


### PR DESCRIPTION
We can attach any debug kconfig or board specific defconfig with the
scripts.

EG: ../kconfig/kconfig-sof-default.sh ../kconfig/debug-defconfig

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>