### PR TITLE
base-defconfig: add I2C_HID as module to enable touchpad

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -171,6 +171,8 @@ CONFIG_MOUSE_ELAN_SMBUS=y
 CONFIG_HID_MULTITOUCH=m
 CONFIG_ACPI_WMI=m
 CONFIG_WMI_BMOF=m
+
+# I2C touchpad (Dell, Asus and many other laptops)
 CONFIG_I2C_HID=m
 
 # USB Sound Card Support


### PR DESCRIPTION
Enable I2C_HID to enable touchpad mouse. Used on a lot of
laptops.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>