### PR TITLE
base-defconfig: support suspend-resume on Samus (Broadwell PixelBook …

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -200,3 +200,9 @@ CONFIG_LEDS_TRIGGER_AUDIO=m
 # USB Sound Card Support
 CONFIG_SND_USB=y
 CONFIG_SND_USB_AUDIO=m
+
+# Suspend-resume support on Broadwell Samus (Pixelbook 2015)
+CONFIG_TCG_TPM=y
+CONFIG_TCG_TIS_CORE=y
+CONFIG_TCG_TIS=y
+CONFIG_HW_RANDOM_TPM=y


### PR DESCRIPTION
…2015)

The added configurations are needed to avoid a reboot with
rtcwake -m mem -s 3

The following configurations don't seem needed:

 CONFIG_TCG_TIS_SPI=m
 # CONFIG_TCG_TIS_SPI_CR50 is not set
 CONFIG_TCG_TIS_I2C_ATMEL=m
 CONFIG_TCG_TIS_I2C_INFINEON=m
 CONFIG_TCG_TIS_I2C_NUVOTON=m
 CONFIG_TCG_NSC=m
 CONFIG_TCG_ATMEL=m
 CONFIG_TCG_INFINEON=m
 CONFIG_TCG_XEN=m
 CONFIG_TCG_CRB=y
 CONFIG_TCG_VTPM_PROXY=m
 CONFIG_TCG_TIS_ST33ZP24=m
 CONFIG_TCG_TIS_ST33ZP24_I2C=m
 CONFIG_TCG_TIS_ST33ZP24_SPI=m
 CONFIG_TELCLOCK=m

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>