### PR TITLE
kconfig: enable pmc_core debugfs in default kernel

### DIFF
--- a/kconfig-sof-default.sh
+++ b/kconfig-sof-default.sh
@@ -26,4 +26,5 @@ $COMMAND .config \
 	 $KCONFIG_DIR/sof-dev-defconfig  \
 	 $KCONFIG_DIR/mach-driver-defconfig \
 	 $KCONFIG_DIR/hdaudio-codecs-defconfig \
+	 $KCONFIG_DIR/telemetry-debugfs-defconfig \
 	 $KCONFIG_DIR/soundwire-defconfig $@


### PR DESCRIPTION
Add pmc_core debugfs to default kernel config
for wake on voice pipeline test.

Signed-off-by: Amery Song <chao.song@intel.com>