### PR TITLE
base-config: add ALSA control checks

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -1,6 +1,9 @@
 CONFIG_EXPERT=y
 CONFIG_DYNAMIC_DEBUG=y
 
+# ALSA configurations
+CONFIG_SND_CTL_VALIDATION=y
+
 # Enable OF match for PRP0001 ACPI devices
 CONFIG_OF=y
 


### PR DESCRIPTION
This option seems to wreck the SOF driver handling of ALSA controls.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>