### PR TITLE
Use a standard link to the kernel source tree instead of guessing

### DIFF
--- a/kconfig-sof-default.sh
+++ b/kconfig-sof-default.sh
@@ -10,7 +10,7 @@ if test -f "$FILE"; then
     COMMAND=$FILE;
 else
     # try if the script in a work directory without the -build path
-    CODE_DIR=${BUILD_DIR%-build}
+    CODE_DIR=source
     if test -f "$CODE_DIR/$FILE"; then
 	COMMAND=$CODE_DIR/$FILE;
     else


### PR DESCRIPTION
No need to try to guess the kernel source path, there is a "source" link to it in the build directory.
