### PR TITLE
base-defconfig: enable /proc/config.gz as a module

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -1,6 +1,10 @@
 CONFIG_EXPERT=y
 CONFIG_DYNAMIC_DEBUG=y
 
+# sudo modprobe configs && zgrep SOF_DEBUG /proc/config.gz
+CONFIG_IKCONFIG=m
+CONFIG_IKCONFIG_PROC=y
+
 # ALSA configurations
 CONFIG_SND_CTL_VALIDATION=y
 


### PR DESCRIPTION
No need to manually preserve .config files to check what changed
recently.

This is especially useful when .config is generated from fragments and
has to be moved around because these generation scripts do not support
out of tree O= builds.

As a module it uses no resource unless requested, so I can't find any
drawback.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>