### PR TITLE
base-defconfig: build netconsole as module

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -1,6 +1,9 @@
 CONFIG_EXPERT=y
 CONFIG_DYNAMIC_DEBUG=y
 
+# build netconsole as module to configure it with /etc/modprobe.d
+CONFIG_NETCONSOLE=m
+
 # sudo modprobe configs && zgrep SOF_DEBUG /proc/config.gz
 CONFIG_IKCONFIG=m
 CONFIG_IKCONFIG_PROC=y


### PR DESCRIPTION
This is required to configure it with module options.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>