### PR TITLE
Support for kernels build using any build directory via O=<any path>

### DIFF
--- a/kconfig-hda.sh
+++ b/kconfig-hda.sh
@@ -2,22 +2,7 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 
-BUILD_DIR=$(pwd)
-
-# find merge_config in code directory
-FILE=scripts/kconfig/merge_config.sh
-if test -f "$FILE"; then
-    COMMAND=$FILE;
-else
-    # try if the script in a work directory without the -build path
-    CODE_DIR=${BUILD_DIR%-build}
-    if test -f "$CODE_DIR/$FILE"; then
-	COMMAND=$CODE_DIR/$FILE;
-    else
-	echo "error: could not find $FILE";
-	exit 1;
-    fi
-fi
+. $KCONFIG_DIR/kconfig-lib.sh
 
 make defconfig
 $COMMAND .config \

--- a/kconfig-lib.sh
+++ b/kconfig-lib.sh
@@ -1,0 +1,17 @@
+
+BUILD_DIR=$(pwd)
+
+# find merge_config in code directory
+FILE=scripts/kconfig/merge_config.sh
+if test -f "$FILE"; then
+    COMMAND=$FILE;
+else
+    # try if the script in a work directory without the -build path
+    CODE_DIR=${BUILD_DIR%-build}
+    if test -f "$CODE_DIR/$FILE"; then
+        COMMAND=$CODE_DIR/$FILE;
+    else
+        echo "error: could not find $FILE";
+        exit 1;
+    fi
+fi

--- a/kconfig-lib.sh
+++ b/kconfig-lib.sh
@@ -11,7 +11,13 @@ else
     if test -f "$CODE_DIR/$FILE"; then
         COMMAND=$CODE_DIR/$FILE;
     else
-        echo "error: could not find $FILE";
-        exit 1;
+        # try if the script is accessible via the source symlink
+        SOURCE_DIR=$BUILD_DIR/source
+        if test -f "$SOURCE_DIR/$FILE"; then
+            COMMAND=$SOURCE_DIR/$FILE;
+        else
+            echo "error: could not find $FILE";
+            exit 1;
+        fi
     fi
 fi

--- a/kconfig-sof-arm64.sh
+++ b/kconfig-sof-arm64.sh
@@ -2,22 +2,7 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 
-BUILD_DIR=$(pwd)
-
-# find merge_config in code directory
-FILE=scripts/kconfig/merge_config.sh
-if test -f "$FILE"; then
-    COMMAND=$FILE;
-else
-    # try if the script in a work directory without the -build path
-    CODE_DIR=${BUILD_DIR%-build}
-    if test -f "$CODE_DIR/$FILE"; then
-	COMMAND=$CODE_DIR/$FILE;
-    else
-	echo "error: could not find $FILE";
-	exit 1;
-    fi
-fi
+. $KCONFIG_DIR/kconfig-lib.sh
 
 make defconfig ARCH=arm64
 $COMMAND -m .config \

--- a/kconfig-sof-default.sh
+++ b/kconfig-sof-default.sh
@@ -2,22 +2,7 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 
-BUILD_DIR=$(pwd)
-
-# find merge_config in code directory
-FILE=scripts/kconfig/merge_config.sh
-if test -f "$FILE"; then
-    COMMAND=$FILE;
-else
-    # try if the script in a work directory without the -build path
-    CODE_DIR=${BUILD_DIR%-build}
-    if test -f "$CODE_DIR/$FILE"; then
-	COMMAND=$CODE_DIR/$FILE;
-    else
-	echo "error: could not find $FILE";
-	exit 1;
-    fi
-fi
+. $KCONFIG_DIR/kconfig-lib.sh
 
 make defconfig
 $COMMAND .config \

--- a/kconfig-sof-nocodec.sh
+++ b/kconfig-sof-nocodec.sh
@@ -2,22 +2,7 @@
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 
-BUILD_DIR=$(pwd)
-
-# find merge_config in code directory
-FILE=scripts/kconfig/merge_config.sh
-if test -f "$FILE"; then
-    COMMAND=$FILE;
-else
-    # try if the script in a work directory without the -build path
-    CODE_DIR=${BUILD_DIR%-build}
-    if test -f "$CODE_DIR/$FILE"; then
-	COMMAND=$CODE_DIR/$FILE;
-    else
-	echo "error: could not find $FILE";
-	exit 1;
-    fi
-fi
+. $KCONFIG_DIR/kconfig-lib.sh
 
 make defconfig
 $COMMAND .config \


### PR DESCRIPTION
The kernel build output dir can be anywhere in the filesystem, not limited
to build directory under the kernel source tree.

For reference my usual setup is:
```
~/work/kernel/linux                             - kernel source
~/work/kernel/_kbuild_output/linux/x86_64/      - x86_64 build dir
~/work/kernel/_kbuild_output/linux/x86/         - x86 32bit build dir
~/work/kernel/_kbuild_output/linux/aarch64/     - ARM64 build dir
~/work/kernel/_kbuild_output/linux/arm/         - ARM32 build dir
~/work/kernel/_kbuild_output/linux/mips/        - MIPS build dir

```