### PR TITLE
kconfig-sof-codec: add soundwire detection

### DIFF
--- a/kconfig-sof-nocodec.sh
+++ b/kconfig-sof-nocodec.sh
@@ -11,4 +11,5 @@ $COMMAND .config \
 	 $KCONFIG_DIR/sof-dev-defconfig \
 	 $KCONFIG_DIR/nocodec-defconfig \
 	 $KCONFIG_DIR/lock-stall-defconfig \
+	 $KCONFIG_DIR/soundwire-defconfig \
 	 $@


### PR DESCRIPTION
This patch is required to run the nocodec mode on SoundWire platforms.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>