### PR TITLE
Revert "kconfig-sof-codec: add soundwire detection"

### DIFF
--- a/kconfig-sof-nocodec.sh
+++ b/kconfig-sof-nocodec.sh
@@ -11,5 +11,4 @@ $COMMAND .config \
 	 $KCONFIG_DIR/sof-dev-defconfig \
 	 $KCONFIG_DIR/nocodec-defconfig \
 	 $KCONFIG_DIR/lock-stall-defconfig \
-	 $KCONFIG_DIR/soundwire-defconfig \
 	 $@


### PR DESCRIPTION
Reverts thesofproject/kconfig#56

This leads to issues on multiple fronts.