### PR TITLE
base-defconfig: add three options required to boot some Fedora spins 

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -21,6 +21,11 @@ CONFIG_BTRFS_FS=y
 CONFIG_BTRFS_FS_POSIX_ACL=y
 CONFIG_FUSE_FS=m
 
+# Required to boot some Fedora spins with default settings.
+CONFIG_DM_THIN_PROVISIONING=y
+CONFIG_XFS_FS=y
+CONFIG_IOSCHED_BFQ=y
+
 # Memory management
 CONFIG_FRONTSWAP=y
 


### PR DESCRIPTION
The Fedora installer uses DM thin provisioning and XFS by default for
some Fedora flavors.

Default udev rules in Fedora have ATTR{queue/scheduler}="bfq" for eMMC
devices in file '60-block-scheduler.rules'.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>