### PR TITLE
base-defconfig: add support for I2C_HID/ISH

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -244,6 +244,10 @@ CONFIG_WMI_BMOF=m
 
 # I2C touchpad (Dell, Asus and many other laptops)
 CONFIG_I2C_HID=m
+CONFIG_I2C_HID_ACPI=m
+CONFIG_I2C_HID_CORE=m
+CONFIG_INTEL_ISH_HID=m
+CONFIG_INTEL_ISH_FIRMWARE_DOWNLOADER=m
 
 # Touchpad support for Broadwell Samus (Pixelbook 2015)
 CONFIG_TOUCHSCREEN_ATMEL_MXT=m


### PR DESCRIPTION
Some TigerLake laptops need support for I2C_HID for the touchpad to
work. Blind bisection with other configurations helped identify the
options, I am not sure all of them are needed but that's already good
enough.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>