### PR TITLE
kconfig: add two scripts to update distro config to sof and sof-dev

### DIFF
--- a/kconfig-distro-sof-dev-update.sh
+++ b/kconfig-distro-sof-dev-update.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
+echo $KCONFIG_DIR
+
+. $KCONFIG_DIR/kconfig-lib.sh
+
+echo "-sof" > localversion
+make olddefconfig
+make localmodconfig
+
+$COMMAND .config \
+	 $KCONFIG_DIR/sof-defconfig  \
+	 $KCONFIG_DIR/sof-dev-defconfig  \
+	 $KCONFIG_DIR/amd-defconfig \
+	 $KCONFIG_DIR/mach-driver-defconfig \
+	 $KCONFIG_DIR/hdaudio-codecs-defconfig \
+	 $KCONFIG_DIR/lock-stall-defconfig \
+	 $KCONFIG_DIR/soundwire-defconfig \
+	 $@

--- a/kconfig-distro-sof-dev-update.sh
+++ b/kconfig-distro-sof-dev-update.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 

--- a/kconfig-distro-sof-update.sh
+++ b/kconfig-distro-sof-update.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
+echo $KCONFIG_DIR
+
+. $KCONFIG_DIR/kconfig-lib.sh
+
+echo "-sof" > localversion
+make olddefconfig
+make localmodconfig
+
+$COMMAND .config \
+	 $KCONFIG_DIR/sof-defconfig  \
+	 $KCONFIG_DIR/amd-defconfig \
+	 $KCONFIG_DIR/mach-driver-defconfig \
+	 $KCONFIG_DIR/hdaudio-codecs-defconfig \
+	 $KCONFIG_DIR/lock-stall-defconfig \
+	 $KCONFIG_DIR/soundwire-defconfig \
+	 $@

--- a/kconfig-distro-sof-update.sh
+++ b/kconfig-distro-sof-update.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 

--- a/kconfig-hda.sh
+++ b/kconfig-hda.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 

--- a/kconfig-minimize-distro-add-sof-defaults.sh
+++ b/kconfig-minimize-distro-add-sof-defaults.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 

--- a/kconfig-sof-arm64.sh
+++ b/kconfig-sof-arm64.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 

--- a/kconfig-sof-default.sh
+++ b/kconfig-sof-default.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 

--- a/kconfig-sof-nocodec.sh
+++ b/kconfig-sof-nocodec.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 KCONFIG_DIR=$(dirname ${BASH_SOURCE[0]})
 echo $KCONFIG_DIR
 


### PR DESCRIPTION
To enable SOF on a platform, it may be easier to start from the
existing distro configurations.

kconfig-distro-sof-update.sh adds the minimal SOF options needed
kconfig-distro-sof-dev-update.sh: adds the SOF developer options

Most users would need the first script only.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>