### PR TITLE
Disable CONFIG_HYPERVISOR_GUEST to revert new upstream default

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -13,6 +13,11 @@ CONFIG_THERMAL=y
 CONFIG_THERMAL_GOV_STEP_WISE=y
 CONFIG_THERMAL_GOV_USER_SPACE=y
 
+# This default value (and many others) were changed by upstream commit:
+#   410ce3dd5055b x86/config: Make the x86 defconfigs a bit more usable
+# Disable it again.
+# CONFIG_HYPERVISOR_GUEST is not set
+
 # SElinux
 CONFIG_SECURITY_SELINUX_DISABLE=y
 


### PR DESCRIPTION
Upstream commit [v5.17-rc2-4111-g410ce3dd5055](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=v5.17-rc2-4111-g410ce3dd5055) changed the default values
of CONFIG_HYPERVISOR_GUEST, CONFIG_PARAVIRT, CONFIG_KVM_GUEST,
CONFIG_PTP_1588_CLOCK_KVM and a couple hundreds others

410ce3dd5055b x86/config: Make the x86 defconfigs a bit more usable

We probably don't care about the new error message `kernel: fail to
initialize ptp_kvm` from CONFIG_PTP_1588_CLOCK_KVM but I think we do
care about all the others, notably:

```
config PARAVIRT
        bool "Enable paravirtualization code"
        depends on HAVE_STATIC_CALL
        help
          This changes the kernel so it can modify itself when it is run
          under a hypervisor, potentially improving performance significantly
          over full virtualization.  However, when run without a hypervisor
          the kernel is theoretically slower and slightly larger.

config KVM_GUEST
        bool "KVM Guest support (including kvmclock)"
        depends on PARAVIRT
        select PARAVIRT_CLOCK
        select ARCH_CPUIDLE_HALTPOLL
        select X86_HV_CALLBACK_VECTOR
        default y
        help
          This option enables various optimizations for running under the KVM
          hypervisor. It includes a paravirtualized clock, so that instead
          of relying on a PIT (or probably other) emulation by the
          underlying device model, the host provides the guest with
          timing infrastructure such as time of day, and system time
```

So go back to where we were: no guest features, code and optimizations.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>