### PR TITLE
base-defconfig: enable coretemp sensor driver

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -13,6 +13,9 @@ CONFIG_THERMAL=y
 CONFIG_THERMAL_GOV_STEP_WISE=y
 CONFIG_THERMAL_GOV_USER_SPACE=y
 
+# Core temperature sensor
+CONFIG_SENSORS_CORETEMP=y
+
 # This default value (and many others) were changed by upstream commit:
 #   410ce3dd5055b x86/config: Make the x86 defconfigs a bit more usable
 # Disable it again.


### PR DESCRIPTION
This module can be used on UP Xtreme board to
monitor core temperature, enable it to reduce
the onboard fan noise.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

After enable the kernel kconfig, use the utility here for fan speed auto-control: https://downloads.up-community.org/download/upx-tgl01-fan-control-linux/