### PR TITLE
Switch Intel E100* Ethernet drivers from built-in to modules

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -104,6 +104,12 @@ CONFIG_USB_XHCI_PLATFORM=m
 # Gigabit Ethernet for MinnowBoard Turbot D0/ i211
 CONFIG_IGB=m
 
+# Override linux/arch/x86/configs/x86_64_deconfig:
+# make them modules so they can be blocklisted when needed.
+CONFIG_E100=m
+CONFIG_E1000=m
+CONFIG_E1000E=m
+
 # WIFI
 CONFIG_CFG80211_WEXT=y
 CONFIG_MAC80211_RC_MINSTREL_VHT=y


### PR DESCRIPTION
These common Intel Ethernet interfaces are built-in by default in
`x86_64_defconfig`:
```
CONFIG_E100=y
CONFIG_E1000=y
CONFIG_E1000E=y
```
Maybe because we often use pre-production hardware, our kernel logs
and test results keep getting polluted by scary error messages like
`e1000e 0000:00:1f.6 eno1: Hardware Error` even when we don't use these
interfaces but a USB dongle instead.

Make these drivers modular so they can blocklisted when we don't use
them. As we never try to boot from the network so this should not
change anything for systems that do use these drivers and do not try
to block them.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>