### PR TITLE
base-defconfig: add X86_X2APIC

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -378,3 +378,7 @@ CONFIG_RT2800USB_RT3573=y
 CONFIG_RT2800USB_RT53XX=y
 CONFIG_RT2800USB_RT55XX=y
 CONFIG_RT2800USB_UNKNOWN=y
+
+# some systems are locked to X86_X2APIC and can not fall back to the
+#  legacy APIC modes if SGX or TDX are enabled in the BIOS
+CONFIG_X86_X2APIC=y


### PR DESCRIPTION
Some Intel systems circa 2022 and later are locked into x2APIC mode and can not fall back to the legacy APIC modes if SGX or TDX are enabled in the BIOS.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>