### PR TITLE
hdaudio-codecs-defconfig: enable silent-streaming for HDMI codec

### DIFF
--- a/hdaudio-codecs-defconfig
+++ b/hdaudio-codecs-defconfig
@@ -7,6 +7,9 @@ CONFIG_SND_SOC_SOF_HDA_AUDIO_CODEC=y
 # switch to common HDMI codec (patch_hdmi.c)
 CONFIG_SND_SOC_SOF_HDA_COMMON_HDMI_CODEC=y
 
+# enable silent stream (aka Keep-Alive) for HDMI codec
+CONFIG_SND_HDA_INTEL_HDMI_SILENT_STREAM=y
+
 # machine driver for HDaudio support
 CONFIG_SND_SOC_INTEL_SKL_HDA_DSP_GENERIC_MACH=m
 


### PR DESCRIPTION
Enable CONFIG_SND_HDA_INTEL_HDMI_SILENT_STREAM by default for HDMI code.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>