### PR TITLE
base-defconfig: add CONFIG_FB_EFI

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -73,6 +73,8 @@ CONFIG_NETCONSOLE=m
 # confusing. Linux distributions expect this.
 CONFIG_FB=y
 CONFIG_FRAMEBUFFER_CONSOLE=y
+# add support for using the EFI framebuffer as console
+CONFIG_FB_EFI=y
 
 # sudo modprobe configs && zgrep SOF_DEBUG /proc/config.gz
 CONFIG_IKCONFIG=m


### PR DESCRIPTION
This is the EFI frame buffer device driver, the UEFI firmware version on our platforms is UEFI 2.0. We need to enable it for using the EFI framebuffer as console. This can solve the no graphics issue on MTL platform under nomodeset mode.

Signed-off-by: Keqiao Zhang <keqiao.zhang@intel.com>