### PR TITLE
base-defconfig: enable Intel MTL VPU driver

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -384,3 +384,7 @@ CONFIG_RT2800USB_UNKNOWN=y
 # some systems are locked to X86_X2APIC and can not fall back to the
 #  legacy APIC modes if SGX or TDX are enabled in the BIOS
 CONFIG_X86_X2APIC=y
+
+# To eanble Intel MTL VPU driver
+CONFIG_DRM_ACCEL=y
+CONFIG_DRM_ACCEL_IVPU=m


### PR DESCRIPTION
Loading VPU driver is required for power measurement.

Discussion is going on. Need FW for VPU also.

VPU should be enabled in BIOS setting, by default it is enabled. We had to disable VPU for recent RVPs. We will test the RVP again with VPU driver loading properly.