### PR TITLE
kconfig-sof-nocodec: add telemetry-debugfs

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -15,10 +15,10 @@ jobs:
     name: "GCC build X86_64"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch linux
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'thesofproject/linux'
           path: 'linux'
@@ -27,6 +27,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libelf-dev
+
+      - name: Install debhelper
+        run: |
+          sudo apt update
+          sudo apt install -y debhelper
 
       - name: build start
         run: |
@@ -41,10 +46,10 @@ jobs:
     name: "GCC build i386"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch linux
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'thesofproject/linux'
           path: 'linux'
@@ -63,10 +68,10 @@ jobs:
     name: "GCC build arm64"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch linux
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'thesofproject/linux'
           path: 'linux'
@@ -90,10 +95,10 @@ jobs:
     name: "Clang build x86_64"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch linux
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'thesofproject/linux'
           path: 'linux'

--- a/kconfig-sof-nocodec.sh
+++ b/kconfig-sof-nocodec.sh
@@ -14,6 +14,7 @@ $COMMAND .config \
 	 $KCONFIG_DIR/sof-dev-defconfig \
 	 $KCONFIG_DIR/amd-defconfig \
 	 $KCONFIG_DIR/nocodec-defconfig \
+	 $KCONFIG_DIR/telemetry-debugfs-defconfig \
 	 $KCONFIG_DIR/lock-stall-defconfig \
 	 $KCONFIG_DIR/bpf-defconfig \
 	 $@


### PR DESCRIPTION
This is a major difference with the 'default' configuration, and as a result of not having the PMC core enabled we infer the wrong conclusions.

The difference with the 'default' configuration should only be related to HDAudio and SoundWire removed.