### PR TITLE
sof-dev-config: add CONFIG_USB_SERIAL_CP210X=m

### DIFF
--- a/sof-dev-defconfig
+++ b/sof-dev-defconfig
@@ -30,3 +30,15 @@ CONFIG_SND_SOC_SOF_SKYLAKE_SUPPORT=y
 
 # generic ACPI audio compositor
 CONFIG_SND_ACPI_AUDIO_COMPOSITOR=m
+
+# This USB-serial converter is embedded on current Intel development
+# boards.  Note the converter chip is on the USB gadget / Type-B / test
+# device side, whereas this cp210x.ko driver runs on the USB host /
+# Type-A / "workstation" side. So why include this driver on test
+# devices = on the "wrong" side?  Because it's much easier to connect
+# two test devices which are already next to each other rather trying to
+# sneak a new USB host on a crowded lab shelf or trying to use a laptop
+# help up in the air. Also, these are modules so not loaded unless
+# actually in use.
+CONFIG_USB_SERIAL=m
+CONFIG_USB_SERIAL_CP210X=m


### PR DESCRIPTION
As no one ever wanted to boot from a microphone, it's very rare that we have to use the serial console to debug very early boot issues. But it can happen, see for instance
- https://github.com/thesofproject/linux/pull/4799

In such case it's very convenient to use another test device to collect logs on the serial console.