### PR TITLE
base-defconfig: make ACPI_FAN / fan.ko a module so we can blocklist it

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -146,6 +146,9 @@ CONFIG_INT340X_THERMAL=m
 CONFIG_INT3406_THERMAL=m
 CONFIG_INTEL_PCH_THERMAL=m
 
+# Make fan.ko a module so we can blocklist it on some problematic devices
+CONFIG_ACPI_FAN=m
+
 #
 # Generic IOMMU Pagetable Support
 #


### PR DESCRIPTION
New driver: new, 6.10 error on cml-hel-rt5682.

```
kernel: acpi-fan INT3404:00: probe with driver acpi-fan failed with error -22
```

Easily avoided by blocklisting fan.ko on this model.

Part of the fix for:
- https://github.com/thesofproject/sof-test/issues/1198