### PR TITLE
kconfig-sof-default: use xrun-debug by default

### DIFF
--- a/kconfig-sof-default.sh
+++ b/kconfig-sof-default.sh
@@ -19,6 +19,7 @@ $COMMAND .config \
 	 "$KCONFIG_DIR"/hdaudio-codecs-defconfig \
 	 "$KCONFIG_DIR"/telemetry-debugfs-defconfig \
 	 "$KCONFIG_DIR"/lock-stall-defconfig \
+	 "$KCONFIG_DIR"/xrun-debug-defconfig \
 	 "$KCONFIG_DIR"/soundwire-defconfig \
 	 "$KCONFIG_DIR"/soundwire-codecs-defconfig \
 	 "$KCONFIG_DIR"/bpf-defconfig \


### PR DESCRIPTION
For some reason the Intel CI uses an extra config required by the sof-test xrun_injection tests.

Make sure developers and CI rely on the same .config.