### PR TITLE
base-defconfig: Enable CONFIG_INTEL_IDLE

### DIFF
--- a/base-defconfig
+++ b/base-defconfig
@@ -216,3 +216,5 @@ CONFIG_DEVFREQ_GOV_PASSIVE=m
 # some systems are locked to X86_X2APIC and can not fall back to the
 #  legacy APIC modes if SGX or TDX are enabled in the BIOS
 CONFIG_X86_X2APIC=y
+
+CONFIG_INTEL_IDLE=y


### PR DESCRIPTION
The config is is required to allow the DUT to enter PC10 state.